### PR TITLE
patch: Use pointers to prevent unexpected values assign

### DIFF
--- a/pkg/duit_attributes/duit_color/color.go
+++ b/pkg/duit_attributes/duit_color/color.go
@@ -22,5 +22,5 @@ func (color *ColorRGBO) MarshalJSON() ([]byte, error) {
 }
 
 type Color interface {
-	ColorString | ColorRGBO
+	ColorString |  *ColorRGBO
 }

--- a/pkg/duit_attributes/duit_decorations/box_decoration.go
+++ b/pkg/duit_attributes/duit_decorations/box_decoration.go
@@ -7,6 +7,6 @@ type BoxDecoration[T duit_color.Color] struct {
 	Boder        *BorderSide[T]     `json:"border,omitempty"`
 	BorderRadius float32            `json:"borderRadius,omitempty"`
 	Shape        BoxShape           `json:"shape,omitempty"`
-	BoxShadow    []BoxShadow[T]     `json:"boxShadow"`
+	BoxShadow    []BoxShadow[T]     `json:"boxShadow,omitempty"`
 	Gradient     *LinearGradient[T] `json:"gradient,omitempty"`
 }

--- a/pkg/duit_attributes/mod_test.go
+++ b/pkg/duit_attributes/mod_test.go
@@ -4,14 +4,18 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/Duit-Foundation/duit_go/v3/pkg/duit_attributes/duit_color"
+	duit_decoration "github.com/Duit-Foundation/duit_go/v3/pkg/duit_attributes/duit_decorations"
+	"github.com/Duit-Foundation/duit_go/v3/pkg/duit_attributes/duit_edge_insets"
 	"github.com/Duit-Foundation/duit_go/v3/pkg/duit_attributes/duit_painting"
+	"github.com/Duit-Foundation/duit_go/v3/pkg/duit_utils"
 )
 
 func TestBackdropFilter(t *testing.T) {
 	blur := duit_painting.NewBlurImageFilter(1, 2, "")
 
 	attr := &BackdropFilterAttributes[duit_painting.BlurImageFilter]{
-		Filter: blur,
+		Filter:    blur,
 		BlendMode: duit_painting.Clear,
 	}
 
@@ -19,5 +23,68 @@ func TestBackdropFilter(t *testing.T) {
 
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestContainerAttributes(t *testing.T) {
+	cont := &ContainerAttributes[duit_edge_insets.EdgeInsetsAll, *duit_color.ColorRGBO]{
+		Decoration: &duit_decoration.BoxDecoration[*duit_color.ColorRGBO]{
+			Color: &duit_color.ColorRGBO{R: 255, G: 0, B: 0, O: 1},
+		},
+	}
+
+	j, err := json.Marshal(cont)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val := map[string]interface{}{}
+
+	err = json.Unmarshal(j, &val)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if val["decoration"] == nil {
+		t.Fatal("decoration is nil")
+	}
+
+	if val["color"] != nil {
+		t.Fatal("color is not nil")
+	}
+}
+
+func TestSafeAreaAttributes(t *testing.T) {
+	cont := &SafeAreaAttributes[duit_edge_insets.EdgeInsetsAll]{
+		Top: duit_utils.BoolPtr(false),
+		Bottom: duit_utils.BoolPtr(true),
+	}
+
+	j, err := json.Marshal(cont)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val := map[string]interface{}{}
+
+	err = json.Unmarshal(j, &val)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if val["top"] != false {
+		t.Fatal("top is nil")
+	}
+
+	if val["bottom"] != true {
+		t.Fatal("botton is nil")
+	}
+
+	if val["right"] != nil {
+		t.Fatal("right is not nil")
 	}
 }

--- a/pkg/duit_attributes/safe_area_attributes.go
+++ b/pkg/duit_attributes/safe_area_attributes.go
@@ -8,10 +8,10 @@ import (
 type SafeAreaAttributes[TInsets duit_edge_insets.EdgeInsets] struct {
 	ValueReferenceHolder
 	animations.AnimatedPropertyOwner
-	Left                      bool    `json:"left,omitempty"`
-	Top                       bool    `json:"top,omitempty"`
-	Right                     bool    `json:"right,omitempty"`
-	Bottom                    bool    `json:"bottom,omitempty"`
+	Left                      *bool    `json:"left,omitempty"`
+	Top                       *bool    `json:"top,omitempty"`
+	Right                     *bool    `json:"right,omitempty"`
+	Bottom                    *bool    `json:"bottom,omitempty"`
 	Minimum                   TInsets `json:"minimum,omitempty"`
-	MaintainBottomViewPadding bool    `json:"maintainBottomViewPadding,omitempty"`
+	MaintainBottomViewPadding *bool    `json:"maintainBottomViewPadding,omitempty"`
 }

--- a/pkg/duit_utils/ptr.go
+++ b/pkg/duit_utils/ptr.go
@@ -1,0 +1,8 @@
+package duit_utils
+
+func BoolPtr(v bool) *bool {
+	ptr := new(bool)
+
+	*ptr = v
+	return ptr
+}


### PR DESCRIPTION
- Added `BoolPtr` helper
- Fixed issue with SafeAreaAttributes
- Fixed same issue with ColorRGBO struct